### PR TITLE
Enable editing recruitment records and search

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -512,10 +512,16 @@
                 <label class="md-label" for="positionDescription">Description</label>
                 <textarea id="positionDescription" name="description" class="md-textarea" rows="3" placeholder="Add role highlights or notes"></textarea>
               </div>
-              <button type="submit" class="md-button md-button--filled md-button--small">
-                <span class="material-symbols-rounded">save</span>
-                Save Position
-              </button>
+              <div class="form-actions">
+                <button id="positionSubmitBtn" type="submit" class="md-button md-button--filled md-button--small">
+                  <span id="positionSubmitIcon" class="material-symbols-rounded">save</span>
+                  <span class="position-submit-label">Save Position</span>
+                </button>
+                <button id="positionCancelEditBtn" type="button" class="md-button md-button--text md-button--small hidden">
+                  <span class="material-symbols-rounded">close</span>
+                  Cancel Edit
+                </button>
+              </div>
             </form>
           </div>
 
@@ -561,12 +567,18 @@
               <div class="md-field">
                 <label class="md-label" for="candidateCv">Upload CV</label>
                 <input id="candidateCv" name="cv" type="file" accept=".pdf,.doc,.docx,.docm,.rtf" required>
-                <p class="text-muted" style="margin-top:4px;">Accepted formats: PDF or Word documents.</p>
+                <p id="candidateCvHelpText" class="text-muted" style="margin-top:4px;">Accepted formats: PDF or Word documents.</p>
               </div>
-              <button type="submit" class="md-button md-button--filled">
-                <span class="material-symbols-rounded">upload_file</span>
-                Add to Pipeline
-              </button>
+              <div class="form-actions">
+                <button id="candidateSubmitBtn" type="submit" class="md-button md-button--filled">
+                  <span id="candidateSubmitIcon" class="material-symbols-rounded">upload_file</span>
+                  <span class="candidate-submit-label">Add to Pipeline</span>
+                </button>
+                <button id="candidateCancelEditBtn" type="button" class="md-button md-button--text hidden">
+                  <span class="material-symbols-rounded">close</span>
+                  Cancel Edit
+                </button>
+              </div>
             </form>
           </div>
 
@@ -581,14 +593,33 @@
                   <th>Candidate</th>
                   <th>Contact</th>
                   <th>Status</th>
+                  <th class="candidate-actions-header">Actions</th>
                 </tr>
               </thead>
               <tbody id="candidateTableBody">
                 <tr>
-                  <td colspan="3" class="text-muted" style="padding:16px; font-style: italic;">Select a position to view candidates.</td>
+                  <td colspan="4" class="text-muted" style="padding:16px; font-style: italic;">Select a position to view candidates.</td>
                 </tr>
               </tbody>
             </table>
+          </div>
+
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">manage_search</span>
+              Candidate Lookup
+            </div>
+            <p class="card-subtitle">Find applicants across every position to check their previous submissions.</p>
+            <div class="md-field table-search">
+              <label class="md-label" for="candidateSearchInput">Search candidates</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">search</span>
+                <input id="candidateSearchInput" type="text" class="md-input" placeholder="Search by name or contact" autocomplete="off" spellcheck="false">
+              </div>
+            </div>
+            <div id="candidateSearchResults" class="candidate-search-results text-muted">
+              Start typing to look up existing applicants.
+            </div>
           </div>
         </div>
       </section>

--- a/public/styles.css
+++ b/public/styles.css
@@ -133,3 +133,115 @@
   font-size: 0.9em;
 }
 
+.form-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.form-actions .md-button--text {
+  margin-left: auto;
+}
+
+.position-item {
+  padding: 0;
+  gap: 0;
+  cursor: default;
+}
+
+.position-item__select {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.position-item__select:focus {
+  outline: none;
+}
+
+.position-item__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-right: 12px;
+}
+
+.position-item__actions .md-button {
+  white-space: nowrap;
+}
+
+.candidate-actions-header {
+  width: 140px;
+}
+
+.candidate-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.candidate-actions .md-button {
+  padding-inline: 8px;
+}
+
+.candidate-search-results {
+  margin-top: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 56px;
+}
+
+.candidate-search-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+}
+
+.candidate-search-item__name {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.candidate-search-item__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.candidate-search-item__status {
+  font-weight: 600;
+  color: var(--md-sys-color-primary, #6750a4);
+}
+
+.candidate-search-empty {
+  font-style: italic;
+}
+
+.candidate-search-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.candidate-search-loading .material-symbols-rounded {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+


### PR DESCRIPTION
## Summary
- add recruitment UI controls for editing positions, managing candidates, and searching existing applicants
- extend recruitment pipeline scripts with edit/delete flows, form state management, and cross-position search handling
- expose backend endpoints to update positions, update/delete candidates, and search applicants by name/contact

## Testing
- `npm start` *(fails: MongoDB connection refused in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e612f570f8832e9199d7093203c1f5