### PR TITLE
Reposition candidate lookup card at top of recruitment panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -486,6 +486,26 @@
           <p class="panel-subtitle">Open roles and monitor every candidate from first touch to hiring.</p>
         </div>
 
+        <div class="card-grid card-grid--single">
+          <div class="md-card">
+            <div class="card-title">
+              <span class="material-symbols-rounded">manage_search</span>
+              Candidate Lookup
+            </div>
+            <p class="card-subtitle">Find applicants across every position to check their previous submissions.</p>
+            <div class="md-field table-search">
+              <label class="md-label" for="candidateSearchInput">Search candidates</label>
+              <div class="md-input-wrapper">
+                <span class="material-symbols-rounded">search</span>
+                <input id="candidateSearchInput" type="text" class="md-input" placeholder="Search by name or contact" autocomplete="off" spellcheck="false">
+              </div>
+            </div>
+            <div id="candidateSearchResults" class="candidate-search-results text-muted">
+              Start typing to look up existing applicants.
+            </div>
+          </div>
+        </div>
+
         <div class="card-grid">
           <div class="md-card">
             <div class="card-title">
@@ -604,23 +624,6 @@
             </table>
           </div>
 
-          <div class="md-card">
-            <div class="card-title">
-              <span class="material-symbols-rounded">manage_search</span>
-              Candidate Lookup
-            </div>
-            <p class="card-subtitle">Find applicants across every position to check their previous submissions.</p>
-            <div class="md-field table-search">
-              <label class="md-label" for="candidateSearchInput">Search candidates</label>
-              <div class="md-input-wrapper">
-                <span class="material-symbols-rounded">search</span>
-                <input id="candidateSearchInput" type="text" class="md-input" placeholder="Search by name or contact" autocomplete="off" spellcheck="false">
-              </div>
-            </div>
-            <div id="candidateSearchResults" class="candidate-search-results text-muted">
-              Start typing to look up existing applicants.
-            </div>
-          </div>
         </div>
       </section>
 

--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -637,6 +637,10 @@ body {
   gap: 20px;
 }
 
+.card-grid--single {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .md-card {
   background: rgba(248, 250, 255, 0.85);
   border-radius: 24px;


### PR DESCRIPTION
## Summary
- move the candidate lookup card to the first grid within the recruitment panel so it appears before other cards
- add a single-column grid helper so the lookup card spans the full width of the layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e61ab34d68832ebbc897e1f894327b