### PR TITLE
Fix Open Positions list layout

### DIFF
--- a/public/material-theme.css
+++ b/public/material-theme.css
@@ -1779,7 +1779,7 @@ body {
 
 .position-item {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 12px;
   width: 100%;
   padding: 12px 16px;
@@ -1789,6 +1789,30 @@ body {
   cursor: pointer;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
   text-align: left;
+}
+
+.position-item__select {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+}
+
+.position-item__select:focus-visible {
+  outline: 3px solid rgba(103, 80, 164, 0.35);
+  outline-offset: 4px;
+  border-radius: 12px;
+}
+
+.position-item__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .position-item:hover {


### PR DESCRIPTION
## Summary
- ensure Open Positions items stretch to the full card width regardless of title length
- add layout and focus styles for the position selection control and action area

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e61e3b26d0832eb0f8eee33eb7660d